### PR TITLE
Fix UI artifact when video player is created

### DIFF
--- a/SKPhotoBrowser/SKZoomingScrollView.swift
+++ b/SKPhotoBrowser/SKZoomingScrollView.swift
@@ -29,7 +29,7 @@ open class SKZoomingScrollView: UIScrollView {
     fileprivate var videoPlayer: SKVideoPlayer!
     fileprivate var playButton: UIButton!
     fileprivate var downloadButton: SKDownloadButton!
-
+    
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         setup()
@@ -513,6 +513,7 @@ private extension SKZoomingScrollView {
         }
         
         videoPlayer = SKVideoPlayer(URL: photo.videoURL)
+        videoPlayer.frame = self.bounds
         videoPlayer.delegate = self
         layer.addSublayer(videoPlayer.layer())
     }


### PR DESCRIPTION
The video frame is enlarged from the top right corner in an animation when the user presses play the first time.